### PR TITLE
Add default security policy

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,13 @@
+# Security Policy
+
+Please DO NOT report security vulnerabilities using a public GitHub issue. If you believe you've found a security issue, please contact us through one of the following methods:
+- Using GitHub security advisories: `https://github.com/saleor/<repository-name>/security/advisories` (replace `<repository-name>`)
+- https://huntr.dev/bounties/disclose/
+- Alternatively, through our mailing list: security@saleor.io
+
+We do not currently have a bounty program in place, so we cannot offer monetary rewards for any reported problems.
+
+You can claim bounty rewards by reporting vulnerabilities using Huntr: https://huntr.dev.
+
+Whichever method you choose, you will be credited as the reporter once the announcement is published.
+


### PR DESCRIPTION
This adds a default (generic) security policy for our GitHub organization. All repositories that do not contain `/SECURITY.md` or `.github/SECURITY.md` will automatically use our default one.