### PR TITLE
Updated SECURITY.md with reporting guidelines

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,10 +1,35 @@
 # Security Policy
 
-Please DO NOT report security vulnerabilities using a public GitHub issue. If you believe you've found a security issue, please contact us through one of the following methods:
+> [!WARNING]
+> DO NOT report security vulnerabilities using a public GitHub issue.
+
+If you believe you've found a security issue, please contact us through one of the following methods:
+
 - Using GitHub security advisories: `https://github.com/saleor/<repository-name>/security/advisories` (replace `<repository-name>`)
 - Alternatively, through our mailing list: security@saleor.io
 
-We do not currently have a bounty program in place, so we cannot offer monetary rewards for any reported problems.
-
 Whichever method you choose, you will be credited as the reporter once the announcement is published.
 
+## Guidelines
+
+A report must include:
+
+- A clear description of the issue
+- Reproduction steps that allow us to verify the behavior
+- Affected version(s) and environment details (versions, OS, tools, configurations)
+- Let us know if you are willing to review the patches before their publication
+
+Reports that lack these elements may be considered incomplete and may be closed without follow-up,
+reports may also be closed if the submitter does not engage to follow-ups.
+
+## Automated Reports
+
+We do not accept:
+
+- Low-effort or automatically generated reports (including AI-generated content)
+- Reports that are bulk-submitted without context or verification
+- Reports that are not addressing feedback or questions
+
+## No Monetary Rewards
+
+We do not have a bounty program in place, so we cannot offer monetary rewards for any reported problems.


### PR DESCRIPTION
Expanded the security policy to include reporting guidelines and criteria for submissions in order to help ensure reports respect the maintainers' time

This is inspired by https://sethmlarson.dev/respecting-maintainer-time-should-be-in-security-policies (Seth Larson, Security Developer at PSF)